### PR TITLE
Add DOST-based tfpws algorithm

### DIFF
--- a/stackmaster/core.py
+++ b/stackmaster/core.py
@@ -23,7 +23,7 @@ def stack(d,method,par=None):
     ds: stacked data, which may be a list depending on the method.
     """
     method_list=["linear","pws","robust","acf","nroot","selective",
-            "cluster","tfpws"]
+            "cluster","tfpws","tfpws_fast"]
     if method not in method_list:
         raise ValueError("$s not recoganized. use one of $s"%(method,str(method_list)))
     par0={"axis":0,"p":2,"g":1,"cc_min":0.0,"epsilon":1E-5,"maxstep":10,
@@ -39,6 +39,8 @@ def stack(d,method,par=None):
         ds = pws(d,p=par['p'])
     elif method.lower() == 'tfpws':
         ds = tfpws(d,p=par['p'])
+    elif method.lower() == 'tfpws_fast':
+        ds = tfpws_fast(d,p=par['p'])
     elif method.lower() == 'robust':
         ds = robust(d,epsilon=par['epsilon'],maxstep=par['maxstep'],win=par["win"],
                 stat=par['stat'],ref=par['ref'])
@@ -369,7 +371,7 @@ def tfpws(d,p=2,axis=0):
     Performs time-frequency domain phase-weighted stack on array of time series.
 
     $C_{ps} = |(\sum{S*e^{i2\pi}/|S|})/M|^p$, where $C_{ps}$ is the phase weight. Then
-    $S_{pws} = C_{ps}*S_{ls}$, where $S_{ls}$ is the S transform of the linea stack
+    $S_{pws} = C_{ps}*S_{ls}$, where $S_{ls}$ is the S transform of the linear stack
     of the whole data.
 
     Reference:
@@ -410,3 +412,124 @@ def tfpws(d,p=2,axis=0):
     newstack=st.ist(pwstock)
     #
     return newstack
+
+def tfpws_fast(d,p=2,axis=0):
+    '''
+    Performs time-frequency domain phase-weighted stack on array of time series.
+
+    $C_{ps} = |(\sum{S*e^{i2\pi}/|S|})/M|^p$, where $C_{ps}$ is the phase weight. Then
+    $S_{pws} = C_{ps}*S_{ls}$, where $S_{ls}$ is the Discrete Orthonormal S transform 
+    of the linear stack of the whole data.
+
+    Reference:
+    U. Battisti, L. Riba, "Window-dependent bases for efficient representations of the 
+    Stockwell transform", Applied and Computational Harmonic Analysis, 23 February 2015,
+    http://dx.doi.org/10.1016/j.acha.2015.02.002.
+
+
+    PARAMETERS:
+    ---------------------
+    d: N length array of time series data (numpy.ndarray)
+    p: exponent for phase stack (int). default is 2
+
+    RETURNS:
+    ---------------------
+    newstack: Phase weighted stack of time series data (numpy.ndarray)
+    '''
+    if d.ndim == 1:
+        print('2D matrix is needed')
+        return d
+    N,M = d.shape
+
+    #get the dost of the linear stack first
+    lstack=np.mean(d,axis=axis)
+    stock_ls_dost=DOST(lstack) # initialize dost object
+    stock_ls=stock_ls_dost.dost(stock_ls_dost.data) # calculate the dost
+
+    # calculate dost for first trace to know its shape
+    stock_dost=DOST(d[0])
+    stock_temp=stock_dost.dost(stock_dost.data)
+    # initialize stack
+    phase_stack=np.zeros(len(stock_temp),dtype='complex128')
+    # calculate the dost for each trace to be stacked
+    for i in range(d.shape[0]):
+        if i>0: # zero index has been computed
+            stock_dost=DOST(d[i])
+            stock_temp=stock_dost.dost(stock_dost.data)
+        phase_stack+=np.multiply(stock_temp,np.angle(stock_temp))/np.abs(stock_temp)
+
+    phase_stack = np.abs(phase_stack/N)**p
+
+    pwstock=np.multiply(phase_stack,stock_ls)
+    recdostIn = stock_dost.idost(pwstock)
+    recdostIn = recdostIn[:M] # trim padding
+
+    return recdostIn
+
+class DOST:
+    def __init__(self, data):
+        # make sure data length is a power of 2
+        if np.ceil(np.log2(len(data)))==np.floor(np.log2(len(data))):
+            # length of data already a power of 2
+            self.data=data
+        else:
+            # pad data to nearest power of 2
+            self.data=self.pad(data)
+
+    def pad(self,data):
+        """Zero pad data such that its length is a power of 2"""
+        N=int(2**np.ceil(np.log2(len(data))))
+        pad_end=np.zeros(int(N-len(data)))
+        data=np.concatenate((data,pad_end))
+
+        return data
+
+    def fourier(self, d):
+        """Normalize and center fft"""
+        fftIn=(1/np.sqrt(len(d))) * np.fft.fftshift(np.fft.fft(np.fft.ifftshift(d)))
+        return fftIn
+
+    def ifourier(self,d):
+        """Normalize and center ifft"""
+        ifftIn=np.sqrt(len(d)) * np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(d)))
+        return ifftIn
+
+    def dostbw(self,D):
+        """Calculate size of the DOST bandwidths"""
+        arr=[0]
+        arr.extend(np.arange(np.log2(D)-2, -1e-9, -1))
+        arr.extend([0])
+        arr.extend(np.arange(0, np.log2(D)-2+1e-9))
+        arr=2**np.array(arr)
+        return arr
+
+    def dost(self,d):
+        """Discrete Orthonormal Stockwell Transform"""
+        d_dost=self.fourier(d)
+        D=len(d)
+        bw=self.dostbw(D)
+        k=0
+        for i in bw:
+            i=int(i)
+            if i==1:
+                k=k+i
+            else:
+                d_dost[k:k+i] = self.ifourier(d_dost[k:k+i])
+                k=k+i
+        return d_dost
+
+    def idost(self,d):
+        """Inverse Discrete Orthonormal Stockwell Transform"""
+        d_idost=d
+        D=len(d)
+        bw=self.dostbw(D)
+        k=0
+        for i in bw:
+            i=int(i)
+            if i==1:
+                k=k+i
+            else:
+                d_idost[k:k+i] = self.fourier(d_idost[k:k+i])
+                k=k+i
+        d_idost = self.ifourier(d_idost)
+        return d_idost

--- a/stackmaster/core.py
+++ b/stackmaster/core.py
@@ -477,7 +477,16 @@ class DOST:
             self.data=self.pad(data)
 
     def pad(self,data):
-        """Zero pad data such that its length is a power of 2"""
+        """Zero pad data such that its length is a power of 2
+
+        PARAMETERS:
+        ---------------------
+        data: array of time series data (numpy.ndarray)
+
+        RETURNS:
+        ---------------------
+        data: zero-padded array of time series data (numpy.ndarray)
+        """
         N=int(2**np.ceil(np.log2(len(data))))
         pad_end=np.zeros(int(N-len(data)))
         data=np.concatenate((data,pad_end))
@@ -485,30 +494,67 @@ class DOST:
         return data
 
     def fourier(self, d):
-        """Normalize and center fft"""
+        """Normalized and centered fft
+
+        PARAMETERS:
+        ---------------------
+        d: array of time series data (numpy.ndarray)
+
+        RETURNS:
+        ---------------------
+        fftIn: array of frequency-domain data (numpy.ndarray)
+        """
         fftIn=(1/np.sqrt(len(d))) * np.fft.fftshift(np.fft.fft(np.fft.ifftshift(d)))
         return fftIn
 
     def ifourier(self,d):
-        """Normalize and center ifft"""
+        """Normalized and centered ifft
+        
+        PARAMETERS:
+        ---------------------
+        d: array of frequency-domain data (numpy.ndarray)
+
+        RETURNS:
+        ---------------------
+        ifftIn: array of time series data (numpy.ndarray)
+        """
         ifftIn=np.sqrt(len(d)) * np.fft.fftshift(np.fft.ifft(np.fft.ifftshift(d)))
         return ifftIn
 
     def dostbw(self,D):
-        """Calculate size of the DOST bandwidths"""
-        arr=[0]
-        arr.extend(np.arange(np.log2(D)-2, -1e-9, -1))
-        arr.extend([0])
-        arr.extend(np.arange(0, np.log2(D)-2+1e-9))
-        arr=2**np.array(arr)
-        return arr
+        """Calculate size of the DOST bandwidths
+
+        PARAMETERS:
+        ---------------------
+        D: length of time-series data (int)
+
+        RETURNS:
+        ---------------------
+        bw: list of DOST bandwidths
+        """
+        bw=[0]
+        bw.extend(np.arange(np.log2(D)-2, -1e-9, -1))
+        bw.extend([0])
+        bw.extend(np.arange(0, np.log2(D)-2+1e-9))
+        bw=2**np.array(bw)
+        return bw
 
     def dost(self,d):
-        """Discrete Orthonormal Stockwell Transform"""
+        """Discrete Orthonormal Stockwell Transform
+
+        PARAMETERS:
+        ---------------------
+        d: array of time-series data (numpy.ndarray)
+
+        RETURNS:
+        ---------------------
+        d_dost: array of DOST coefficients (numpy.ndarray)
+        """
         d_dost=self.fourier(d)
         D=len(d)
         bw=self.dostbw(D)
         k=0
+        # heuristically, this is a short-time fourier transform with a frequency-dependent bandwidth
         for i in bw:
             i=int(i)
             if i==1:
@@ -519,7 +565,16 @@ class DOST:
         return d_dost
 
     def idost(self,d):
-        """Inverse Discrete Orthonormal Stockwell Transform"""
+        """Inverse Discrete Orthonormal Stockwell Transform
+
+        PARAMETERS:
+        ---------------------
+        d: array of DOST coefficients (numpy.ndarray)
+
+        RETURNS:
+        ---------------------
+        d_idost: array of time-series data (numpy.ndarray)
+        """
         d_idost=d
         D=len(d)
         bw=self.dostbw(D)


### PR DESCRIPTION
Time-frequency phase weighted stacking based on the full stockwell transform can be too costly to compute for large datasets. This pull request adds an additional stacking method (tfpws_fast) based on  the discrete orthonormal stockwell transform (DOST), which is essentially a short-time fourier transform with frequency-dependent bandwidth. The DOST implementation is described in [1] and is essentially a python translation of the Matlab implementation in [2]. 

> [1] U. Battisti, L. Riba, "Window-dependent bases for efficient representations of the Stockwell transform", Applied and Computational Harmonic Analysis, 23 February 2015, http://dx.doi.org/10.1016/j.acha.2015.02.002.
> [2] Luigi Riba (2020). FFT-fast S-transforms: DOST, DCST, DOST2 and DCST2 (https://www.mathworks.com/matlabcentral/fileexchange/53910-fft-fast-s-transforms-dost-dcst-dost2-and-dcst2), MATLAB Central File Exchange. Retrieved November 28, 2020.